### PR TITLE
refs #84 #87: ロードすると効果が消えてしまう問題の対処

### DIFF
--- a/UTA_EncounterControl.js
+++ b/UTA_EncounterControl.js
@@ -345,6 +345,7 @@ var utakata = utakata || {};
          * @return {object} セーブデータに格納するデータ連想配列。
          */
         EncounterControl.prototype.appendSaveContents = function(contents) {
+            // セーブ・ロード効果維持しない場合は何もしない
             if (!utakata.EncounterControl.isRemainSaveAndLoad()) {
                 return;
             }
@@ -366,6 +367,10 @@ var utakata = utakata || {};
          * @param {object} contents セーブデータから読み込んだデータ。
          */
         EncounterControl.prototype.extractSaveContents = function(contents) {
+            // ロード時に意図せず効果が残留しないように一旦状態を初期化
+            this.clearParameter();
+
+            // セーブ・ロード効果維持しない場合は何もしない
             if (!this._remainSaveAndLoad) {
                 return;
             }
@@ -507,6 +512,14 @@ var utakata = utakata || {};
     DataManager.extractSaveContents = function(contents) {
         _DataManager_extractSaveContents.call(this, contents);
         utakata.EncounterControl.extractSaveContents(contents);
+    };
+
+    // ニューゲーム時にエンカウント制御のデータを初期化する
+    var DataManager_setupNewGame = DataManager.setupNewGame;
+    DataManager.setupNewGame = function() {
+        DataManager_setupNewGame.call(this);
+
+        utakata.EncounterControl.clearParameter();
     };
 
 })(utakata);


### PR DESCRIPTION
## 概要
Redmine #77 の対処。  
関連性が深いRedmine #87 の修正も同時に対処。

v1.0.0時点ではエンカウント補正効果はロードすると揮発してしまう状態にある。  
直感的にはロード時に効果が残っていてほしい。

## 変更内容
- セーブデータにエンカウント補正情報を持たせ、ロード時に状態を復元するように。
- v1.0.0以前と挙動が異なる事になるので、プラグインパラメーター`Remain Save and Load`でロード時の状態維持を有効にするか選択できるように。
- エンカウント補正後、タイトルに戻るやロード時に意図せずに効果が残ってしまうバグの修正。
    - これは客観的に見てもバグの挙動なので修正とする。